### PR TITLE
Allow sending meta frames without retain flag by setting an option

### DIFF
--- a/src/Binary/EncodingOptions.cs
+++ b/src/Binary/EncodingOptions.cs
@@ -8,6 +8,7 @@ namespace opc.ua.pubsub.dotnet.binary
     public class EncodingOptions : IEquatable<EncodingOptions>
     {
         public bool LegacyFieldFlagEncoding { get; set; }
+        public bool SendMetaMessageWithoutRetain { get; set; }
 
         public bool Equals( EncodingOptions other )
         {
@@ -19,7 +20,9 @@ namespace opc.ua.pubsub.dotnet.binary
             {
                 return true;
             }
-            return LegacyFieldFlagEncoding == other.LegacyFieldFlagEncoding;
+            return 
+                (LegacyFieldFlagEncoding == other.LegacyFieldFlagEncoding) && 
+                (SendMetaMessageWithoutRetain == other.SendMetaMessageWithoutRetain);
         }
 
         public override bool Equals( object obj )
@@ -41,7 +44,12 @@ namespace opc.ua.pubsub.dotnet.binary
 
         public override int GetHashCode()
         {
-            return LegacyFieldFlagEncoding.GetHashCode();
+            unchecked
+            {
+                int hashCode = LegacyFieldFlagEncoding.GetHashCode();
+                hashCode = ( hashCode * 397 ) ^ ( SendMetaMessageWithoutRetain.GetHashCode() );
+                return hashCode;
+            }
         }
 
         public static bool operator ==( EncodingOptions left, EncodingOptions right )

--- a/src/Client/Client.cs
+++ b/src/Client/Client.cs
@@ -593,7 +593,8 @@ namespace opc.ua.pubsub.dotnet.client
                         List<byte[]> metaChunks = dataSet.GetChunkedMetaFrame( ChunkSize, Options, SequenceNumber++ );
                         foreach ( byte[] chunk in metaChunks )
                         {
-                            Publish( chunk, topicPrefix, dataSet.GetWriterId(), "Meta", dataSet.GetDataSetType(), metaChunks.Count == 1 );
+                            bool retain = ( metaChunks.Count == 1 ) && ( !Options.SendMetaMessageWithoutRetain );
+                            Publish( chunk, topicPrefix, dataSet.GetWriterId(), "Meta", dataSet.GetDataSetType(), retain );
                             UpdateLastKeyAndMetaSentTime( dataSet.GetWriterId() );
                         }
                     }


### PR DESCRIPTION
New option to send meta messages without retain flag.