### PR TITLE
Set correct payload flag for meta messages

### DIFF
--- a/src/Client/Client.cs
+++ b/src/Client/Client.cs
@@ -634,7 +634,7 @@ namespace opc.ua.pubsub.dotnet.client
                                             };
             metaFrame.NetworkMessageHeader = new NetworkMessageHeader
                                              {
-                                                     VersionAndFlags = 0xD1,
+                                                     VersionAndFlags = 0x91,
                                                      ExtendedFlags1  = extendedFlags1,
                                                      ExtendedFlags2  = extendedFlags2,
                                                      PublisherID     = new String( ClientId )

--- a/src/Client/ProcessDataSet.cs
+++ b/src/Client/ProcessDataSet.cs
@@ -348,7 +348,7 @@ namespace opc.ua.pubsub.dotnet.client
                                             };
             NetworkMessageHeader networkMessageHeader = new NetworkMessageHeader
                                                         {
-                                                                VersionAndFlags = 0xD1,
+                                                                VersionAndFlags = 0x91,
                                                                 ExtendedFlags1  = extendedFlags1,
                                                                 ExtendedFlags2  = extendedFlags2,
                                                                 PublisherID     = new String( PublisherId )
@@ -370,21 +370,16 @@ namespace opc.ua.pubsub.dotnet.client
 
         protected NetworkMessageHeader GetChunkedNetworkHeader( bool isMetaMessage = false )
         {
-            byte extendedFlags2 = 0x01;
-            if ( isMetaMessage )
-            {
-                extendedFlags2 = 0x09;
-            }
             NetworkMessageHeader networkHeader = new NetworkMessageHeader();
             networkHeader.PublisherID     = new String( PublisherId );
-            networkHeader.VersionAndFlags = 0xD1;
+            networkHeader.VersionAndFlags = isMetaMessage ? (byte)0x91 : (byte)0xD1;
             networkHeader.ExtendedFlags1 = new ExtendedFlags1
                                            {
                                                    RawValue = 0x84
                                            };
             networkHeader.ExtendedFlags2 = new ExtendedFlags2
                                            {
-                                                   RawValue = extendedFlags2
+                                                   RawValue = isMetaMessage ? (byte)0x09 : (byte)0x01
                                            };
             return networkHeader;
         }

--- a/src/Simulation/TestDataSet.cs
+++ b/src/Simulation/TestDataSet.cs
@@ -84,7 +84,7 @@ namespace opc.ua.pubsub.dotnet.simulation
         {
             NetworkMessageHeader networkHeader = new NetworkMessageHeader();
             networkHeader.PublisherID     = new String( PublisherID );
-            networkHeader.VersionAndFlags = 0xD1;
+            networkHeader.VersionAndFlags = 0x91;
             networkHeader.ExtendedFlags1 = new ExtendedFlags1
                                            {
                                                    RawValue = 0x84

--- a/src/Tests/Binary.Test/RoundTripWithSingleDataPoint.cs
+++ b/src/Tests/Binary.Test/RoundTripWithSingleDataPoint.cs
@@ -12,6 +12,7 @@ using opc.ua.pubsub.dotnet.binary.Messages.Key;
 using opc.ua.pubsub.dotnet.binary.Messages.Meta;
 using NUnit.Framework;
 using opc.ua.pubsub.dotnet.client;
+using opc.ua.pubsub.dotnet.binary.Header;
 
 namespace opc.ua.pubsub.dotnet.binary.test
 {
@@ -111,13 +112,16 @@ namespace opc.ua.pubsub.dotnet.binary.test
             NetworkMessage metaNetworkMessage = decoder.ParseBinaryMessage( encodedMeta );
             Assert.That( metaNetworkMessage, Is.Not.Null );
             Assert.That( metaNetworkMessage, Is.InstanceOf( typeof(MetaFrame) ) );
+            Assert.That( metaNetworkMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.False );
             NetworkMessage deltaNetworkMessage = decoder.ParseBinaryMessage( encodedKey );
             Assert.That( deltaNetworkMessage, Is.Not.Null );
             Assert.That( deltaNetworkMessage, Is.InstanceOf( typeof(DeltaFrame) ) );
+            Assert.That( deltaNetworkMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.True );
             DeltaFrame decodedDeltaMessage = (DeltaFrame)deltaNetworkMessage;
             Assert.That( decodedDeltaMessage,             Is.Not.Null );
             Assert.That( decodedDeltaMessage.Items,       Is.Not.Empty );
             Assert.That( decodedDeltaMessage.Items.Count, Is.EqualTo( 1 ) );
+            Assert.That( decodedDeltaMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.True );
             ProcessDataPointValue decodedDataPoint = (ProcessDataPointValue)decodedDeltaMessage.Items[0];
             Common.AssertDataPointsAreEqual( dataPoint, decodedDataPoint );
         }
@@ -133,15 +137,18 @@ namespace opc.ua.pubsub.dotnet.binary.test
             NetworkMessage metaNetworkMessage = decoder.ParseBinaryMessage( encodedMeta );
             Assert.That( metaNetworkMessage, Is.Not.Null );
             Assert.That( metaNetworkMessage, Is.InstanceOf( typeof(MetaFrame) ) );
+            Assert.That( metaNetworkMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.False );
             NetworkMessage keyNetworkMessage = decoder.ParseBinaryMessage( encodedKey );
             Assert.That( keyNetworkMessage, Is.Not.Null );
             Assert.That( keyNetworkMessage, Is.InstanceOf( typeof(KeyFrame) ) );
-            KeyFrame              decodedKeyMessage = (KeyFrame)keyNetworkMessage;
+            Assert.That( keyNetworkMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.True );
+            KeyFrame decodedKeyMessage = (KeyFrame)keyNetworkMessage;
             ProcessDataPointValue decodedDataPoint  = (ProcessDataPointValue)decodedKeyMessage.Items[0];
             Common.AssertDataPointsAreEqual( dataPoint, decodedDataPoint );
             Assert.That( decodedKeyMessage,             Is.Not.Null );
             Assert.That( decodedKeyMessage.Items,       Is.Not.Empty );
             Assert.That( decodedKeyMessage.Items.Count, Is.EqualTo( 1 ) );
+            Assert.That( decodedKeyMessage.NetworkMessageHeader.UADPFlags.HasFlag( UADPFlags.PayloadHeaderEnabled ), Is.True );
         }
     }
 }


### PR DESCRIPTION
For meta messages the flag "Payload header enabled" has to be 0.